### PR TITLE
feat: Don't stop if the goal is reached

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -359,6 +359,10 @@ namespace mbf_abstract_nav
     //! time before a timeout used for tf requests
     double tf_timeout_;
 
+    /*! Setting this flag to false, will prevent the robot from stopping when
+    /* it reaches the goal */
+    bool stop_on_goal_reached_;
+
     //! dynamic reconfigure config mutex, thread safe param reading and writing
     boost::recursive_mutex configuration_mutex_;
 


### PR DESCRIPTION
  - This prevents the robot from stopping between executing the a set of plans,
  so that the robot can follow multiple plans smoothly and without interruption.
  - This feature can be enabled/disabled by setting the `stop_on_goal_reached` to false/true.