### PR TITLE
Obstacles boundary

### DIFF
--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -401,6 +401,8 @@ bool CostmapNavigationServer::callServiceRefinePlan(mbf_msgs::RefinePlan::Reques
       // omitted as it should already be in refined_plan.
       refined_plan.insert(refined_plan.end(), plan_around_obstacle.begin() + 1,
                           plan_around_obstacle.end());
+      response.obstacles_boundary.poses.push_back(plan[before_obstacle].pose);
+      response.obstacles_boundary.poses.push_back(plan[i].pose);
     }
     else
     {

--- a/mbf_msgs/srv/RefinePlan.srv
+++ b/mbf_msgs/srv/RefinePlan.srv
@@ -8,5 +8,9 @@ float32 tolerance
 #Refined plan
 nav_msgs/Path refined_plan
 
+geometry_msgs/PoseStamped pose_before_obstacle
+geometry_msgs/PoseStamped pose_after_obstacle
+geometry_msgs/PoseArray obstacles_boundary
+
 #True if refining the given plan was possible, otherwise False
 bool success

--- a/mbf_msgs/srv/RefinePlan.srv
+++ b/mbf_msgs/srv/RefinePlan.srv
@@ -8,8 +8,10 @@ float32 tolerance
 #Refined plan
 nav_msgs/Path refined_plan
 
-geometry_msgs/PoseStamped pose_before_obstacle
-geometry_msgs/PoseStamped pose_after_obstacle
+# Every two consecutive poses are referring to the 
+# last free pose before an obstacle and the first free pose after it,
+# For example if there were 3 obstacles along the original plan,
+# this array will contain 6 poses
 geometry_msgs/PoseArray obstacles_boundary
 
 #True if refining the given plan was possible, otherwise False


### PR DESCRIPTION
- Add `obstacles_boundary` field to mbf_msgs/RefinePlan.srv
-  Every two consecutive poses are referring to the last free pose before an obstacle and the first free pose after it, For example, if there were 3 obstacles along the original plan, this array will contain 6 poses
 - This information can be used to find out when the robot got out of the
 original plan and when returned to it.