### PR TITLE
fix(mbf_costmap_nav): Force stop planner if cancel is not supported

### DIFF
--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -367,8 +367,9 @@ bool CostmapNavigationServer::callServiceRefinePlan(mbf_msgs::RefinePlan::Reques
             ROS_INFO_STREAM_NAMED("refine_plan", "Global planner patience has been exceeded! Cancel planning...");
             if (!planning_ptr_->cancel())
             {
-              ROS_WARN_STREAM_THROTTLE_NAMED(2.0, "refine_plan", "Cancel planning failed or is not supported; "
-                "must wait until current plan finish!");
+              ROS_WARN_STREAM_NAMED(2.0, "refine_plan", "Cancel planning failed or is not supported; "
+                "forcing planning thread to stop!");
+              planning_ptr_->stopPlanning();
             }
           }
           else


### PR DESCRIPTION
 - In RefinePlan service callback if the global planner couldn't find
 a global plan and also the `cancel` method was not implemented
 aggressively stop the planner by interrupting its thread.